### PR TITLE
2 Bug Fixes and 1 Feature addition

### DIFF
--- a/business_rule_engine/__init__.py
+++ b/business_rule_engine/__init__.py
@@ -56,7 +56,7 @@ class Rule():
         condition_compiled = self._compile_condition(self.conditions)
         params_condition = self._get_params(params, condition_compiled, set_default_arg, default_arg)
         rvalue_condition = condition_compiled(**params_condition).tolist()
-        if self.codition_requires_bool and not isinstance(rvalue_condition, bool):
+        if self.condition_requires_bool and not isinstance(rvalue_condition, bool):
             raise ConditionReturnValueError('rule: {} - condition does not return a boolean value!'.format(self.rulename))
         self.status = bool(rvalue_condition)
         return rvalue_condition

--- a/business_rule_engine/__init__.py
+++ b/business_rule_engine/__init__.py
@@ -90,7 +90,8 @@ class RuleParser():
 
         for line in text.split('\n'):
             ignore_line = False
-            if line.lower().strip().startswith('rule'):
+            line = line.strip()  # The split on rule name doesn't work for multi-line w/o
+            if line.lower().startswith('rule'):
                 is_condition = False
                 is_action = False
                 rulename = line.split(' ', 1)[1].strip("\"")
@@ -131,6 +132,7 @@ class RuleParser():
         default_arg: Optional[Any] = None
     ) -> bool:
         rule_was_triggered = False
+        rule_results = {}
         for rule in self:
             logging.debug("Rule name: %s", rule.rulename)
             logging.debug("Condition: %s", "".join(rule.conditions))
@@ -140,8 +142,9 @@ class RuleParser():
 
             if rule.status:
                 rule_was_triggered = True
+                rule_results[rule.rulename] = rvalue_action
                 if stop_on_first_trigger:
                     logging.debug("Stop on first trigger")
                     break
                 logging.debug("continue with next rule")
-        return rule_was_triggered
+        return rule_was_triggered, rule_results


### PR DESCRIPTION
1. The check for condition_requires_bool was causing all conditional rules to fail as it was missing an "n"
2. The ```line.lower().strip()``` in the Rule name conditional causes the later ```line.split(' ', 1)[1].strip("\"")``` to get the wrong rule name. The ```strip()``` must get stored back into the line so that the split works in all cases.
3. It seemed strange to just Throw the Results of the Actions away, especially when they were being returned by the Rule class.  Saving the results in a dictionary indexed by the Rule Name makes more sense, seems consistent with the Rule class, and would allow the end-user to keep a log of actions performed or even take further actions based off those results.