### PR TITLE
Compile rule once for increased speed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 
 docs/source/modules
 .vscode/
+.devcontainer/devcontainer.json

--- a/business_rule_engine/__init__.py
+++ b/business_rule_engine/__init__.py
@@ -28,6 +28,8 @@ class Rule():
         self.conditions: List[Text] = []
         self.actions: List[Text] = []
         self.status: Optional[bool] = None
+        self.condition_compiled = None
+        self.action_compiled = None
 
     @staticmethod
     def _compile_condition(condition_lines: List[Text]) -> Any:
@@ -55,7 +57,9 @@ class Rule():
         return params_condition
 
     def check_condition(self, params: Dict[Text, Any], *, set_default_arg: bool = False, default_arg: Any = None) -> Any:
-        condition_compiled = self._compile_condition(self.conditions)
+        if not self.condition_compiled:
+            self.condition_compiled = self._compile_condition(self.conditions)
+        condition_compiled = self.condition_compiled
         params_condition = self._get_params(params, condition_compiled, set_default_arg, default_arg)
         rvalue_condition = condition_compiled(**params_condition).tolist()
         if self.condition_requires_bool and not isinstance(rvalue_condition, bool):
@@ -64,7 +68,9 @@ class Rule():
         return rvalue_condition
 
     def run_action(self, params: Dict[Text, Any], *, set_default_arg: bool = False, default_arg: Any = None) -> Any:
-        action_compiled = self._compile_condition(self.actions)
+        if not self.action_compiled:
+            self.action_compiled = self._compile_condition(self.actions)
+        action_compiled = self.action_compiled
         params_actions = self._get_params(params, action_compiled, set_default_arg, default_arg)
         return action_compiled(**params_actions)
 
@@ -121,6 +127,7 @@ class RuleParser():
                 self.rules[rulename].conditions.append(line.strip())
             if rulename and is_action and not ignore_line:
                 self.rules[rulename].actions.append(line.strip())
+            
 
     def add_rule(self, rulename: Text, condition: Text, action: Text) -> None:
         if rulename in self.rules:

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,0 +1,34 @@
+import time
+import sys
+import os
+sys.path.insert(0, os.getcwd())
+from business_rule_engine import RuleParser
+
+
+def order_more(items_to_order):
+    return "you ordered {} new items".format(items_to_order)
+
+
+rules = """
+rule "order new items"
+when
+    products_in_stock < 20
+then
+    order_more(50)
+end
+"""
+
+parser = RuleParser()
+parser.register_function(order_more)
+parser.parsestr(rules)
+
+params_list = [{'products_in_stock': 10}] * 10_000
+
+start_time = time.time()
+
+for params in params_list:
+    assert parser.execute(params) is True
+
+end_time = time.time()
+execution_time = end_time - start_time
+print(f"Execution time: {execution_time:.3f} seconds")


### PR DESCRIPTION
Compile each rule only once. Increases the speed significantly in case the rules are executed on a list of parameters.